### PR TITLE
Skip the second pass of panfeed for annotate_summary

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -752,7 +752,7 @@ rule run_map_summary_panfeed:
     phenotypes=os.path.join(config["association_inputs"], "{target}/phenotypes.tsv"),
     pangenome=config["pangenome"],
     pangenome2=config["pangenome_csv"],
-    mapped="out/associations/{target}/panfeed_annotated_kmers.tsv.gz",
+    mapped="out/associations/{target}/panfeed_kmers.tsv.gz",
   output:
     summary="out/associations/{target}/summary_panfeed.tsv"
   params:
@@ -1238,6 +1238,27 @@ rule run_panfeed:
            {params.covariates} \
            > {output.p} 2> {log}
     cat <(head -1 {output.p}) <(LC_ALL=C awk -v pval=$(python workflow/scripts/count_patterns.py --threshold {input.patterns}) '$4<pval {{print $0}}' {output.p}) > {output.p_f}
+    """
+
+rule annotate_panfeed_small:
+  input:
+    expand("out/associations/{target}/panfeed_kmers.tsv.gz",
+           target=config["targets"])
+
+rule run_annotate_panfeed_small:
+  input:
+    associations="out/associations/{target}/panfeed.tsv",
+    kmers=config["panfeed_conversion"],
+    patterns="out/associations/{target}/unitigs_patterns.txt",
+  output:
+    "out/associations/{target}/panfeed_kmers.tsv.gz"
+  log: "out/logs/panfeed_annotate_small_{target}.log"
+  shell:
+    """
+    python workflow/scripts/combine_panfeed.py \
+           {input.associations} {input.kmers} \
+           --threshold $(python workflow/scripts/count_patterns.py --threshold {input.patterns}) \
+           | gzip > {output} 2> {log}
     """
 
 rule panfeed:

--- a/workflow/scripts/combine_panfeed.py
+++ b/workflow/scripts/combine_panfeed.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+
+import sys
+import argparse
+import numpy as np
+import pandas as pd
+
+
+def get_options():
+    description = 'Prepare the input for mapped_summary.py for panfeed'
+    parser = argparse.ArgumentParser(description=description)
+
+    parser.add_argument('pyseer',
+                        help='Pyseer results for panfeed '
+                             '(the first column should contain the hashes)')
+    parser.add_argument('kmers',
+                        help='kmers_to_hashes.tsv file from panfeed')
+
+    parser.add_argument('--threshold',
+                        type=float,
+                        default=1,
+                        help='p-value threshold (default: %(default).2f)')
+
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    options = get_options()
+
+    p = pd.read_csv(options.pyseer, sep='\t', index_col=0)
+    p = p[p['lrt-pvalue'] <= options.threshold].copy()
+
+    k = pd.read_csv(options.kmers, sep='\t', index_col=2)
+
+    k.join(p, how='inner').to_csv(sys.stdout, sep='\t')

--- a/workflow/scripts/mapped_summary.py
+++ b/workflow/scripts/mapped_summary.py
@@ -14,7 +14,7 @@ def get_options():
 
     parser.add_argument('mapped',
                         help='Mapped unitigs table (all strains), or annotated k-mers '
-                             'from panfeed-get-kmers (`--panfeed` must be used)')
+                             'from combine_panfeed.py (`--panfeed` must be used)')
     parser.add_argument('phenotypes',
                         help='Phenotypes table')
     parser.add_argument('phenotype',
@@ -24,7 +24,7 @@ def get_options():
 
     parser.add_argument('--panfeed',
                         default=False, action='store_true',
-                        help='Data comes from panfeed-get-kmers')
+                        help='Data comes from combine_panfeed.py')
     parser.add_argument('--sort',
                         default='avg-lrt-pvalue',
                         help='Sort final table using this column (default: %(default)s)')
@@ -110,7 +110,7 @@ if __name__ == "__main__":
         m = pd.read_csv(options.mapped, sep='\t', index_col=9)
         # rename a column to avoid much refactoring
         m = m.rename(columns={'hashed_pattern': 'unitig',
-                              'gene_start': 'start',
+                              'k-mer': 'start',
                               'cluster': 'gene'})
     # check empty
     if m.shape[0] == 0:


### PR DESCRIPTION
In some cases, `panfeed-get-kmers` may require a lot of RAM, which may be inconvenient for some users, especially since it is not strictly needed for the `annotate_summary` rule. This change bypasses the second pass of panfeed to complete the rule, leaving the potentially onerous step to the more explicit `panfeed` rule.

Tested on an actual Pseudomonas dataset by Marco/Jenny

Note: the issue has also potentially been mitigated in [the latest version of panfeed](https://github.com/microbial-pangenomes-lab/panfeed/pull/32)